### PR TITLE
Дададзены базавы канфіг .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -11,3 +11,7 @@ insert_final_newline = true
 
 [*.md]
 trim_trailing_whitespace = false
+
+[*.yml]
+indent_style = space
+indent_size = 2

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# editorconfig.org
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+trim_trailing_whitespace = true
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Гэта першы крок выправіць код-стайл на праекце

Прапанова выкарыстоўваць 4 прабела (гэта бадай адзінае opinionated рашэнне, але і яна на дадзены момент самае папулярнае ў PHP кам'юніці).
Усе астатняе - відавочнае думаю

https://editorconfig.org/

>EditorConfig helps developers define and maintain consistent coding styles between different editors and IDEs. The EditorConfig project consists of a file format for defining coding styles and a collection of text editor plugins that enable editors to read the file format and adhere to defined styles. EditorConfig files are easily readable and they work nicely with version control systems.


Для editorconfig існуюць плагіны пад усе папулярныя IDE і рэдактары

